### PR TITLE
Fix: Resolve error when searching items and videos

### DIFF
--- a/src/main/java/Soma/CLOVI/domain/category/Category.java
+++ b/src/main/java/Soma/CLOVI/domain/category/Category.java
@@ -43,8 +43,7 @@ public class Category extends BaseTimeEntity {
   @OneToMany(mappedBy = "ParentCategory", cascade = {CascadeType.PERSIST,CascadeType.MERGE})
   private List<Category> childCategories =  new ArrayList<>();
 
-  public boolean isParent(){
-    return this.depth.equals(0) ? true : false;
+  public boolean isParent() {
+    return this.depth.equals(0);
   }
-
 }

--- a/src/main/java/Soma/CLOVI/dto/response/TimeShopItemResponseDto.java
+++ b/src/main/java/Soma/CLOVI/dto/response/TimeShopItemResponseDto.java
@@ -34,6 +34,8 @@ class ItemOrderComparator implements Comparator<ItemAffiliateLinkResponseDto> {
     int orderA = A.getItem().getOrder();
     int orderB = B.getItem().getOrder();
 
+    // No need to check if null
+
     return Integer.compare(orderA, orderB);
   }
 }

--- a/src/main/java/Soma/CLOVI/dto/response/VideoResponseDto.java
+++ b/src/main/java/Soma/CLOVI/dto/response/VideoResponseDto.java
@@ -37,6 +37,8 @@ class TimeOrderComparator implements Comparator<TimeShopItemResponseDto> {
     Long orderA = A.getTimes().getStart();
     Long orderB = B.getTimes().getStart();
 
+    if(orderA == null || orderB == null) return 0;
+
     return Long.compare(orderA, orderB);
   }
 }


### PR DESCRIPTION
When /search GET request was sent from the client, Internal Server Error 500 occurred for some specific conditions.
- **https://test.clovi.app/api/v1/search?parent_category=11&size=48** <- This works fine!
- **https://test.clovi.app/api/v1/search?parent_category=6&size=48** <- This doesn't work..

After analyzing the server code, I have concluded that this happened after JaeSeok added a feature to sort timeframes in ascending order in each video.
`NullPointerException` was the main cause as there was no validation to check for null values while sorting in TimeOrderComparator.

This bug can be resolved by the following 2 solutions:
1. Check if Category.order is null in TimeOrderComparator in VideoResponseDto
2. Avoid adding null value in "order" attribute in "Category" table

Now I chose the first solution, but null value must not exist in "order" attribute in "Category" table from the first place. We should try to figure out why this happened.
- Is the original value accidentally deleted by mistake when manually changing values using MySQL Workbench?
- Or there is a problem in our logic when adding data from our data entry page?

These kind of questions should also be addressed when refactoring our server code after our initial release.