### PR TITLE
Feat: Enable keyword search by channel, parent category, child category

### DIFF
--- a/src/main/java/Soma/CLOVI/repository/Item/ItemRepositoryCustomImpl.java
+++ b/src/main/java/Soma/CLOVI/repository/Item/ItemRepositoryCustomImpl.java
@@ -71,10 +71,18 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     private BooleanExpression keywordContains(String searchKeyword) {
         if(searchKeyword == null) return null;
 
-        BooleanExpression conditionA = item.name.contains(searchKeyword);
-        BooleanExpression conditionB = item.brand.eq(searchKeyword);
+        BooleanExpression queryItem1 = item.name.containsIgnoreCase(searchKeyword);
+        BooleanExpression queryItem2 = item.brand.containsIgnoreCase(searchKeyword);
 
-        return conditionA.or(conditionB);
+        BooleanExpression queryVideo1 = video.title.containsIgnoreCase(searchKeyword);
+        BooleanExpression queryVideo2 = video.channel.name.containsIgnoreCase(searchKeyword);
+
+        BooleanExpression queryCategory1 = category.ParentCategory.name.equalsIgnoreCase(searchKeyword);
+        BooleanExpression queryCategory2 = category.name.equalsIgnoreCase(searchKeyword);
+
+        return (queryItem1).or(queryItem2)
+                .or(queryVideo1).or(queryVideo2)
+                .or(queryCategory1).or(queryCategory2);
     }
 
     private BooleanExpression channelEq(String channelName) {

--- a/src/main/java/Soma/CLOVI/repository/Video/VideoRepositoryCustomImpl.java
+++ b/src/main/java/Soma/CLOVI/repository/Video/VideoRepositoryCustomImpl.java
@@ -86,10 +86,18 @@ public class VideoRepositoryCustomImpl implements VideoRepositoryCustom {
     private BooleanExpression keywordContains(String searchKeyword) {
         if(searchKeyword == null) return null;
 
-        BooleanExpression conditionA = video.title.contains(searchKeyword);
-        BooleanExpression conditionB = item.brand.eq(searchKeyword);
+        BooleanExpression queryVideo1 = video.title.containsIgnoreCase(searchKeyword);
+        BooleanExpression queryVideo2 = video.channel.name.containsIgnoreCase(searchKeyword);
 
-        return conditionA.or(conditionB);
+        BooleanExpression queryItem1 = item.name.containsIgnoreCase(searchKeyword);
+        BooleanExpression queryItem2 = item.brand.containsIgnoreCase(searchKeyword);
+
+        BooleanExpression queryCategory1 = category.ParentCategory.name.equalsIgnoreCase(searchKeyword);
+        BooleanExpression queryCategory2 = category.name.equalsIgnoreCase(searchKeyword);
+
+        return (queryVideo1).or(queryVideo2)
+                .or(queryItem1).or(queryItem2)
+                .or(queryCategory1).or(queryCategory2);
     }
 
     private BooleanExpression channelEq(String channelName) {


### PR DESCRIPTION
### Expanded search scope for user input keyword

- **Item list**
  - All items whose `item name` **_contains_** keyword
  - All items whose `item brand name` **_contains_** keyword
  - All items shown in [videos whose `video title` **_contains_** keyword]
  - All items shown in [videos whose `video channel name` **_contains_** keyword]
  - All items whose `item parent category name` **_exactly matches with_** keyword
  - All items whose `item child category name` **_exactly matches with_** keyword

- **Video list**
  - All videos showing **_at least one_** [item whose `item name` **_contains_** keyword]
  - All videos showing **_at least one_** [item whose `item brand name` **_contains_** keyword]
  - All videos whose `video title` **_contains_** keyword
  - All videos whose `video channel name` **_contains_** keyword
  - All videos showing **_at least one_** [item whose `item parent category name` **_exactly matches with_** keyword]
  - All videos showing **_at least one_** [item whose `item child category name` **_exactly matches with_** keyword]

(+ This is a **_case-insensitive_** search on keyword.)