### PR TITLE
Item, ItemInfo CRUD API 일괄 수정

### DIFF
--- a/src/main/java/com/clovi/api/controller/item/ItemController.java
+++ b/src/main/java/com/clovi/api/controller/item/ItemController.java
@@ -3,24 +3,27 @@ package com.clovi.api.controller.item;
 import com.clovi.api.response.BaseResponse;
 import com.clovi.api.response.MessageCode;
 import com.clovi.api.response.ProcessStatus;
+import com.clovi.domain.user.Member;
 import com.clovi.dto.requests.item.detail.ItemCreateRequest;
 import com.clovi.dto.requests.item.detail.ItemDeleteRequest;
 import com.clovi.dto.requests.item.detail.ItemUpdateRequest;
 import com.clovi.dto.response.IdResponseDto;
+import com.clovi.dto.response.ItemResponseDto;
+import com.clovi.dto.response.MemberResponse;
+import com.clovi.dto.response.ShopItemResponseDto;
 import com.clovi.service.item.ItemService;
+import com.clovi.support.auth.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "유튜버가 입력하는 아이템 색,사이즈 API")
 @RestController
@@ -29,25 +32,40 @@ import org.springframework.web.bind.annotation.RestController;
 public class ItemController {
 
   private final ItemService itemService;
-  @PostMapping("/items/detail")//아이템 상세 생성 API
-  @Operation(summary = "아이템 상세 생성", description = "아이템 상세를 저장한다.")
-  public ResponseEntity createItemDetail(@Validated @RequestBody ItemCreateRequest itemCreateRequest, Long userId){
-    IdResponseDto savedId = new IdResponseDto(itemService.create(itemCreateRequest,userId));
+
+  @GetMapping("/items/{item_id}")//아이템 조회 API
+  @Operation(summary = "Find item", description = "Find item by ID.", responses = {
+          @ApiResponse(responseCode = "200", description = "Success Find item", content = @Content(schema = @Schema(implementation = ItemResponseDto.class)))
+  })
+  public ResponseEntity findShopItemById(@PathVariable(name = "item_id") Long itemId){
+    ItemResponseDto response = itemService.findItemById(itemId);
+    return ResponseEntity.ok(new BaseResponse(response, HttpStatus.OK.value(), MessageCode.SUCCESS_GET));
+  }
+  @PostMapping("/items")//아이템 생성 API
+  @Operation(summary = "Create item", description = "Create item and save", responses = {
+          @ApiResponse(responseCode = "201", description = "Success create", content = @Content(schema = @Schema(implementation = IdResponseDto.class)))
+  })
+  public ResponseEntity createItem(@Validated @RequestBody ItemCreateRequest itemCreateRequest, @AuthMember Member member){
+    IdResponseDto savedId = new IdResponseDto(itemService.create(itemCreateRequest,member));
     return ResponseEntity.created(
-        URI.create("/api/v1/evaluation/" + savedId.getSavedId())).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),
+        URI.create("/api/v1/items" + savedId.getSavedId())).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),
         ProcessStatus.SUCCESS,
         MessageCode.SUCCESS_CREATE));
   }
-  @PutMapping("/items/detail")//아이템 상세 수정 API
-  @Operation(summary = "아이템 상세 수정", description = "아이템 상세를 수정한다.")
-  public ResponseEntity updateItemDetail(@Validated @RequestBody ItemUpdateRequest itemUpdateRequest, Long userId){
-    IdResponseDto savedId = new IdResponseDto(itemService.update(itemUpdateRequest,userId));
+  @PutMapping("/items/{item_id}")//아이템 수정 API
+  @Operation(summary = "Update item", description = "Update item by id", responses = {
+          @ApiResponse(responseCode = "200", description = "Success update", content = @Content(schema = @Schema(implementation = IdResponseDto.class)))
+  })
+  public ResponseEntity updateItem(@Validated @RequestBody ItemUpdateRequest itemUpdateRequest, @PathVariable(name = "item_id") Long itemId, @AuthMember Member member){
+    IdResponseDto savedId = new IdResponseDto(itemService.update(itemUpdateRequest,itemId,member));
     return ResponseEntity.ok(new BaseResponse(savedId,HttpStatus.OK.value(),ProcessStatus.SUCCESS, MessageCode.SUCCESS_UPDATE));
   }
-  @DeleteMapping("/items/detail")//아이템 상세 삭제 API
-  @Operation(summary = "아이템 상세 삭제", description = "아이템 상세를 삭제한다.")
-  public ResponseEntity deleteItemDetail(@Validated @RequestBody ItemDeleteRequest itemDeleteRequest, Long userId){
-    itemService.delete(itemDeleteRequest,userId);
+  @DeleteMapping("/items/{item_id}")//아이템 삭제 API
+  @Operation(summary = "Delete item", description = "Delete item by id", responses = {
+          @ApiResponse(responseCode = "200", description = "Success delete")
+  })
+  public ResponseEntity deleteItem(@Validated @PathVariable(name = "item_id") Long itemId, @AuthMember Member member){
+    itemService.delete(itemId,member);
     return ResponseEntity.ok(new BaseResponse(HttpStatus.OK.value(),ProcessStatus.SUCCESS, MessageCode.SUCCESS_DELETE));
   }
 }

--- a/src/main/java/com/clovi/dto/requests/item/ItemInfoCreateRequest.java
+++ b/src/main/java/com/clovi/dto/requests/item/ItemInfoCreateRequest.java
@@ -25,9 +25,6 @@ public class ItemInfoCreateRequest {
   @Schema(description = "상품 색", example = "black")
   private String color;
 
-  @Schema(description = "카테고리", example = "M")
+  @Schema(description = "카테고리", example = "203")
   private Long categoryId;
-
-  @Schema(description = "사이즈", example = "M")
-  private String size;
 }

--- a/src/main/java/com/clovi/dto/requests/item/ItemInfoUpdateRequest.java
+++ b/src/main/java/com/clovi/dto/requests/item/ItemInfoUpdateRequest.java
@@ -11,10 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ItemInfoUpdateRequest {
 
-  @NotNull(message = "아이템 id는 필수 항목입니다!")
-  @Schema(description = "아이템 id", example = "1")
-  private Long itemId;
-
   @NotBlank(message = "브랜드는 필수 항목입니다!")
   @Schema(description = "브랜드", example = "어누즈")
   private String brand;
@@ -30,9 +26,6 @@ public class ItemInfoUpdateRequest {
   @Schema(description = "상품 색", example = "black")
   private String color;
 
-  @Schema(description = "카테고리", example = "M")
+  @Schema(description = "카테고리", example = "203")
   private Long categoryId;
-
-  @Schema(description = "사이즈", example = "M")
-  private String size;
 }

--- a/src/main/java/com/clovi/dto/requests/item/detail/ItemUpdateRequest.java
+++ b/src/main/java/com/clovi/dto/requests/item/detail/ItemUpdateRequest.java
@@ -8,10 +8,6 @@ import lombok.NoArgsConstructor;
 @Schema(name = "아이템 색상, 사이즈 수정 요청")
 @NoArgsConstructor
 public class ItemUpdateRequest {
-
-  @Schema(description = "item ID", example = "1")
-  private Long itemId;
-
   @Schema(description = "사이즈", example = "M")
   private String size;
 

--- a/src/main/java/com/clovi/dto/response/ColorAndSizeResponseDto.java
+++ b/src/main/java/com/clovi/dto/response/ColorAndSizeResponseDto.java
@@ -1,0 +1,19 @@
+package com.clovi.dto.response;
+
+import com.clovi.domain.item.Item;
+import lombok.Getter;
+
+@Getter
+public class ColorAndSizeResponseDto {
+    private String color;
+    private String size;
+
+    public ColorAndSizeResponseDto(String color, String size) {
+        this.color = color;
+        this.size = size;
+    }
+    public ColorAndSizeResponseDto(Item item) {
+        this.color = item.getColor();
+        this.size = item.getSize();
+    }
+}

--- a/src/main/java/com/clovi/dto/response/ItemResponseDto.java
+++ b/src/main/java/com/clovi/dto/response/ItemResponseDto.java
@@ -5,6 +5,7 @@ import com.clovi.domain.item.ItemInfo;
 import com.clovi.domain.item.Item;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 
@@ -21,7 +22,7 @@ public class ItemResponseDto {
   List<String> colorList = new ArrayList<>();
   List<String> sizeList = new ArrayList<>();
 
-
+  List<ColorAndSizeResponseDto> colorAndSizeList = new ArrayList<>();
   List<ShopItemResponseDto> shops = new ArrayList<>();
   List<ItemResponseDto> childItems = new ArrayList<>();
   public ItemResponseDto(ItemInfo itemInfo) {
@@ -79,5 +80,18 @@ public class ItemResponseDto {
         this.shops.add(new ShopItemResponseDto(shopItem));
       }
     }
+  }
+  public ItemResponseDto(ItemInfo itemInfo, List<Item> item) {
+    this.id = itemInfo.getId();
+    this.name = itemInfo.getName();
+    this.order = itemInfo.getCategory().getOrders();
+    this.brand = itemInfo.getBrand();
+    this.itemImgUrl = itemInfo.getImgUrl();
+    for (ShopItem shopItem : itemInfo.getShopItems()) { // Select ShopItem
+      if(shopItem.getShop().getId() != 100) { // 제휴링크가 아닌 경우에만 추가
+        this.shops.add(new ShopItemResponseDto(shopItem));
+      }
+    }
+    this.colorAndSizeList  = item.stream().map(ColorAndSizeResponseDto::new).collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
공통 변경 사항 
- Read 요청 이외에는 전부 유튜버 권한이 있어야 요청 가능하도록 함.
- 수정, 삭제는 작성자만 가능

ItemInfo
- 기본 요청 경로 : /api/v1/info/items
- 기존에 사용하던 시간에 등장하는 모든 아이템들을 한번에 저장하는 API 더이상 사용하지 않을꺼 같아서 Summary에 Deprecated라고 적어둠

Item
- 기본 경로 : /api/v1/items
- 조회시엔 ItemInfo 까지 전부 보내주도록 로직 작성 (응답 클래스 : ItemResponseDto )