### PR TITLE
Fix : 동일한 ItemId가 조회되는 오류 해결

### DIFF
--- a/src/main/java/com/clovi/app/item/ItemService.java
+++ b/src/main/java/com/clovi/app/item/ItemService.java
@@ -25,11 +25,7 @@ public class ItemService {
   public ItemResponse findItemById(Long itemId) {
 
       Item item = itemRepository.findByIdAndDeletedIsFalse(itemId).orElseThrow(() -> new ResourceNotFoundException("item",itemId));
-
-      Long itemInfoId = item.getItemInfo().getId();
-      ItemInfo itemInfo = itemInfoRepository.findByIdAndDeletedIsFalse(itemInfoId).orElseThrow(() -> new ResourceNotFoundException("itemInfo",itemInfoId));
-
-      return new ItemResponse(itemInfo,item);
+      return ItemResponse.from(item);
 
   }
   @Transactional

--- a/src/main/java/com/clovi/app/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/com/clovi/app/item/dto/request/ItemCreateRequest.java
@@ -18,10 +18,11 @@ public class ItemCreateRequest {
 
   @Schema(description = "사이즈", example = "M")
   private String size;
-  @Schema(description = "컬러", example = "M")
+
+  @Schema(description = "상품 색", example = "black")
   private String color;
 
-  @Schema(description = "선택한 이미지 ", example = "M")
+  @Schema(description = "상품 이미지 링크", example = "https://image.msscdn.net/images/goods_img/20221204/2970721/2970721_1_500.jpg")
   private String imgUrl;
 
   @Builder

--- a/src/main/java/com/clovi/app/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/clovi/app/item/dto/response/ItemResponse.java
@@ -1,6 +1,5 @@
 package com.clovi.app.item.dto.response;
 
-import com.clovi.app.shopItem.ShopItem;
 import com.clovi.app.itemInfo.ItemInfo;
 import com.clovi.app.item.Item;
 import java.util.ArrayList;
@@ -8,89 +7,62 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.clovi.app.shopItem.dto.response.ShopItemResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class ItemResponse {
   private Long id;
-  private String name;
-  private int order;
-  private String itemImgUrl;
-  private String color;
-  private String size;
-  private String brand;
 
-  List<String> colorList = new ArrayList<>();
-  List<String> sizeList = new ArrayList<>();
+  @Schema(description = "아이템 정보 ID", example = "1")
+  private Long itemInfoId;
+
+  @Schema(description = "사이즈", example = "M")
+  private String size;
+  @Schema(description = "브랜드", example = "어누즈")
+  private String brand;
+  @Schema(description = "상품명", example = "엠보 브이넥 니트")
+  private String name;
+  @Schema(description = "상품 이미지 링크", example = "https://image.msscdn.net/images/goods_img/20221204/2970721/2970721_1_500.jpg")
+  private String imgUrl;
+
+  @Schema(description = "상품 색", example = "black")
+  private String color;
+
+  @Schema(description = "정렬순서", example = "1")
+  private int order;
 
   List<ShopItemResponse> shops = new ArrayList<>();
   List<ItemResponse> childItems = new ArrayList<>();
-  public ItemResponse(ItemInfo itemInfo) {
-    this.id = itemInfo.getId();
-    this.name = itemInfo.getName();
-    this.order = itemInfo.getCategory().getOrders();
-    this.brand = itemInfo.getBrand();
-    this.itemImgUrl = itemInfo.getImgUrl();
-    for (ShopItem shopItem : itemInfo.getShopItems()) { // Select ShopItem
-      if(shopItem.getShop().getId() != 100) { // 제휴링크가 아닌 경우에만 추가
-        this.shops.add(new ShopItemResponse(shopItem));
-      }
-    }
-  }
-  public ItemResponse(Item item) {
-    ItemInfo itemInfo = item.getItemInfo();
-    this.id = itemInfo.getId();
-    this.name = itemInfo.getName();
-    this.order = itemInfo.getCategory().getOrders();
-    this.color = item.getColor();
-    this.size = item.getSize();
-    this.brand = itemInfo.getBrand();
-    this.itemImgUrl = itemInfo.getImgUrl();
-    for (ShopItem shopItem : itemInfo.getShopItems()) { // Select ShopItem
-      if(shopItem.getShop().getId() != 100) { // 제휴링크가 아닌 경우에만 추가
-        this.shops.add(new ShopItemResponse(shopItem));
-      }
-    }
-  }
-  public ItemResponse(ItemInfo itemInfo, List<String> colorList, List<String> sizeList) {
-    this.id = itemInfo.getId();
-    this.name = itemInfo.getName();
-    this.order = itemInfo.getCategory().getOrders();
-    this.brand = itemInfo.getBrand();
-    this.itemImgUrl = itemInfo.getImgUrl();
-    this.colorList = colorList;
-    this.sizeList = sizeList;
-    for (ShopItem shopItem : itemInfo.getShopItems()) { // Select ShopItem
-      if(shopItem.getShop().getId() != 100) { // 제휴링크가 아닌 경우에만 추가
-        this.shops.add(new ShopItemResponse(shopItem));
-      }
-    }
+  @Builder
+  public ItemResponse(Long id, Long itemInfoId, String name, int order, String imgUrl, String color, String size, String brand, List<ShopItemResponse> shops, List<ItemResponse> childItems) {
+    this.id = id;
+    this.itemInfoId = itemInfoId;
+    this.name = name;
+    this.order = order;
+    this.imgUrl = imgUrl;
+    this.color = color;
+    this.size = size;
+    this.brand = brand;
+    this.shops = shops;
+    this.childItems = childItems;
   }
 
-  public ItemResponse(ItemInfo itemInfo, Item item) {
-    this.id = itemInfo.getId();
-    this.name = itemInfo.getName();
-    this.color = item.getColor();
-    this.size = item.getSize();
-    this.order = itemInfo.getCategory().getOrders();
-    this.brand = itemInfo.getBrand();
-    this.itemImgUrl = itemInfo.getImgUrl();
-    for (ShopItem shopItem : itemInfo.getShopItems()) { // Select ShopItem
-      if(shopItem.getShop().getId() != 100) { // 제휴링크가 아닌 경우에만 추가
-        this.shops.add(new ShopItemResponse(shopItem));
-      }
-    }
-  }
-  public ItemResponse(ItemInfo itemInfo, List<Item> item) {
-    this.id = itemInfo.getId();
-    this.name = itemInfo.getName();
-    this.order = itemInfo.getCategory().getOrders();
-    this.brand = itemInfo.getBrand();
-    this.itemImgUrl = itemInfo.getImgUrl();
-    for (ShopItem shopItem : itemInfo.getShopItems()) { // Select ShopItem
-      if(shopItem.getShop().getId() != 100) { // 제휴링크가 아닌 경우에만 추가
-        this.shops.add(new ShopItemResponse(shopItem));
-      }
-    }
+  public static ItemResponse from(Item item){
+    ItemInfo itemInfo = item.getItemInfo();
+    return ItemResponse.builder()
+            .id(item.getId())
+            .itemInfoId(itemInfo.getId())
+            .name(itemInfo.getName())
+            .brand(itemInfo.getBrand())
+            .imgUrl(item.getImgUrl())
+            .color(item.getColor())
+            .size(item.getSize())
+            .order(itemInfo.getCategory().getOrders())
+            .shops(itemInfo.getShopItems().stream().filter(shopItem -> shopItem.getShop().getId() != 100)
+                    .map(shopItem -> ShopItemResponse.from(shopItem)).collect(Collectors.toList()))
+            .build();
+
   }
 }

--- a/src/main/java/com/clovi/app/item/dto/response/ItemShopItemResponse.java
+++ b/src/main/java/com/clovi/app/item/dto/response/ItemShopItemResponse.java
@@ -3,6 +3,7 @@ package com.clovi.app.item.dto.response;
 import com.clovi.app.shopItem.ShopItem;
 import com.clovi.app.item.Item;
 import com.clovi.app.shopItem.dto.response.ShopItemResponse;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -11,7 +12,21 @@ public class ItemShopItemResponse {
   private ShopItemResponse shopLink;
 
   public ItemShopItemResponse(ShopItem shopItem, Item item) {
-    this.item = new ItemResponse(item);
-    this.shopLink = (shopItem == null) ? null : new ShopItemResponse(shopItem);
+    this.item = ItemResponse.from(item);
+    this.shopLink = (shopItem == null) ? null : ShopItemResponse.from(shopItem);
+  }
+
+
+  @Builder
+  public ItemShopItemResponse(ItemResponse item, ShopItemResponse shopLink) {
+    this.item = item;
+    this.shopLink = shopLink;
+  }
+
+  public static ItemShopItemResponse from(ShopItem shopItem, Item item){
+    return ItemShopItemResponse.builder()
+            .item(ItemResponse.from(item))
+            .shopLink(ShopItemResponse.from(shopItem))
+            .build();
   }
 }

--- a/src/main/java/com/clovi/app/search/dto/response/SearchResponse.java
+++ b/src/main/java/com/clovi/app/search/dto/response/SearchResponse.java
@@ -13,7 +13,7 @@ public class SearchResponse {
     private final Page<VideoResponse> videos;
 
     public SearchResponse(Page<Item> itemList, Page<Video> videoList) {
-        items = itemList.map(ItemResponse::new);
+        items = itemList.map(item -> ItemResponse.from(item));
         videos = videoList.map(VideoResponse::new);
     }
 }


### PR DESCRIPTION
/api/v1/videos/{youtube_video_id}/timeframes/{time_frame_id}  APi로 해당 시간에 등장하는 모든 아이템 불러오는 곳에서 ItemId가 아니라 ItemInfoId를 불러오는 오류 해결
ItemResponse 를 반환하는 Static Method에서 itemInfoId 와 itemId를 모두 보내주는 방식으로 변경