### PR TITLE
Feature/modify timeshopitem api

### DIFF
--- a/src/main/java/com/clovi/app/timeShopItem/TimeShopItemController.java
+++ b/src/main/java/com/clovi/app/timeShopItem/TimeShopItemController.java
@@ -27,18 +27,21 @@ import java.net.URI;
 public class TimeShopItemController {
     private final TimeShopItemService timeShopItemService;
 
-    // 시간에 대한 item, shopitem 생성 API
-    @PostMapping("/videos/{video_id}/timeframes/{time_frame_id}/items/{item_id}/shopitems/{shop_item_id}")
-    @Operation(summary = "Create timeShopItem Relationship", description = "Create timeShopItem and save", responses = {
-            @ApiResponse(responseCode = "201", description = "Success create", content = @Content(schema = @Schema(implementation = SavedId.class)))
+    // 시간에 대한 item 및 shopItem 연관관계 생성 API
+    @PostMapping("/timeframes/{timeframe_id}")
+    @Operation(summary = "Create relationship between timeframe and item and shopItem", description = "Create a timeShopItem and save.", responses = {
+            @ApiResponse(responseCode = "201", description = "Success create timeShopItem!", content = @Content(schema = @Schema(implementation = SavedId.class)))
     })
-    public ResponseEntity createTimeShopItem(@NotBlank @PathVariable(name = "video_id") Long videoId, @AuthMember Member member, @NotBlank @PathVariable(name = "time_frame_id") Long timeFrameId
-            , @PathVariable(name = "item_id") Long itemId, @PathVariable(name = "shop_item_id") Long shopItemId){
-        SavedId savedId = new SavedId(timeShopItemService.create(member,timeFrameId,itemId,shopItemId));
-        String[] list = {"/api/v1/videos", String.valueOf(videoId), "timeframes", String.valueOf(timeFrameId)};
+    public ResponseEntity createTimeShopItem(@NotBlank @PathVariable(name = "timeframe_id") Long timeframeId,
+                                             @NotBlank @RequestParam(name = "item_id") Long itemId, @NotBlank @RequestParam(name = "shop_item_id") Long shopItemId,
+                                             @AuthMember Member member) {
+        SavedId savedId = new SavedId(timeShopItemService.createTimeShopItem(timeframeId, itemId, shopItemId, member));
+
+        String[] list = {"/api/v1/timeframes", String.valueOf(timeframeId)};
         return ResponseEntity.created(
-                URI.create(String.join("/", list))).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),
-                ProcessStatus.SUCCESS,
-                MessageCode.SUCCESS_CREATE));
+                URI.create(String.join("/", list))
+        ).body(
+                new BaseResponse(savedId, HttpStatus.CREATED.value(), ProcessStatus.SUCCESS, MessageCode.SUCCESS_CREATE)
+        );
     }
 }

--- a/src/main/java/com/clovi/app/timeShopItem/TimeShopItemController.java
+++ b/src/main/java/com/clovi/app/timeShopItem/TimeShopItemController.java
@@ -14,13 +14,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.constraints.NotBlank;
 import java.net.URI;
 
 
-@Tag(name = "[TimeShopItem] 시간에 대한 아이템 및 쇼핑몰링크 관리 API")
+@Tag(name = "[TimeShopItem] 시간에 대한 아이템 및 쇼핑몰 링크 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -32,8 +32,8 @@ public class TimeShopItemController {
     @Operation(summary = "Create relationship between timeframe and item and shopItem", description = "Create a timeShopItem and save.", responses = {
             @ApiResponse(responseCode = "201", description = "Success create timeShopItem!", content = @Content(schema = @Schema(implementation = SavedId.class)))
     })
-    public ResponseEntity createTimeShopItem(@NotBlank @PathVariable(name = "timeframe_id") Long timeframeId,
-                                             @NotBlank @RequestParam(name = "item_id") Long itemId, @NotBlank @RequestParam(name = "shop_item_id") Long shopItemId,
+    public ResponseEntity createTimeShopItem(@Validated @PathVariable(name = "timeframe_id") Long timeframeId,
+                                             @Validated @RequestParam(name = "item_id") Long itemId, @Validated @RequestParam(name = "shop_item_id") Long shopItemId,
                                              @AuthMember Member member) {
         SavedId savedId = new SavedId(timeShopItemService.createTimeShopItem(timeframeId, itemId, shopItemId, member));
 
@@ -50,8 +50,8 @@ public class TimeShopItemController {
     @Operation(summary = "Delete relationship between timeframe and item and shopItem", description = "Delete a timeShopItem.", responses = {
             @ApiResponse(responseCode = "200", description = "Success delete timeShopItem!")
     })
-    public ResponseEntity deleteTimeShopItem(@NotBlank @PathVariable(name = "timeframe_id") Long timeframeId,
-                                             @NotBlank @RequestParam(name = "item_id") Long itemId, @NotBlank @RequestParam(name = "shop_item_id") Long shopItemId,
+    public ResponseEntity deleteTimeShopItem(@Validated @PathVariable(name = "timeframe_id") Long timeframeId,
+                                             @Validated @RequestParam(name = "item_id") Long itemId, @Validated @RequestParam(name = "shop_item_id") Long shopItemId,
                                              @AuthMember Member member) {
         timeShopItemService.deleteTimeShopItem(timeframeId, itemId, shopItemId, member);
         return ResponseEntity.ok(

--- a/src/main/java/com/clovi/app/timeShopItem/TimeShopItemController.java
+++ b/src/main/java/com/clovi/app/timeShopItem/TimeShopItemController.java
@@ -44,4 +44,18 @@ public class TimeShopItemController {
                 new BaseResponse(savedId, HttpStatus.CREATED.value(), ProcessStatus.SUCCESS, MessageCode.SUCCESS_CREATE)
         );
     }
+
+    // 시간에 대한 item 및 shopItem 연관관계 삭제 API
+    @DeleteMapping("/timeframes/{timeframe_id}")
+    @Operation(summary = "Delete relationship between timeframe and item and shopItem", description = "Delete a timeShopItem.", responses = {
+            @ApiResponse(responseCode = "200", description = "Success delete timeShopItem!")
+    })
+    public ResponseEntity deleteTimeShopItem(@NotBlank @PathVariable(name = "timeframe_id") Long timeframeId,
+                                             @NotBlank @RequestParam(name = "item_id") Long itemId, @NotBlank @RequestParam(name = "shop_item_id") Long shopItemId,
+                                             @AuthMember Member member) {
+        timeShopItemService.deleteTimeShopItem(timeframeId, itemId, shopItemId, member);
+        return ResponseEntity.ok(
+                new BaseResponse(HttpStatus.OK.value(), ProcessStatus.SUCCESS, MessageCode.SUCCESS_DELETE)
+        );
+    }
 }

--- a/src/main/java/com/clovi/app/timeShopItem/TimeShopItemRepository.java
+++ b/src/main/java/com/clovi/app/timeShopItem/TimeShopItemRepository.java
@@ -1,9 +1,9 @@
 package com.clovi.app.timeShopItem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface TimeShopItemRepository extends JpaRepository<TimeShopItem,Long> {
-
+    Optional<TimeShopItem> findByTimeIdAndItemIdAndShopItemIdAndDeletedIsFalse(Long timeframeId, Long itemId, Long shopItemId);
     boolean existsByTimeIdAndItemIdAndShopItemIdAndDeletedIsFalse(Long timeId, Long ItemId, Long shopItemId);
-
 }

--- a/src/main/java/com/clovi/app/timeShopItem/TimeShopItemService.java
+++ b/src/main/java/com/clovi/app/timeShopItem/TimeShopItemService.java
@@ -53,7 +53,7 @@ public class TimeShopItemService {
                 .orElseThrow(() -> new ResourceNotFoundException("shopItem", shopItemId));
 
         TimeShopItem timeShopItem = timeShopItemRepository.findByTimeIdAndItemIdAndShopItemIdAndDeletedIsFalse(timeframeId, itemId, shopItemId)
-                .orElseThrow(() -> new ResourceNotFoundException("timeShopItem", ""));
+                .orElseThrow(() -> new ResourceNotFoundException("timeShopItem", timeframeId, itemId, shopItemId));
 
         if(timeShopItem.isNotCreatedBy(member.getId())) {
             throw new NoPermissionDeleteException();

--- a/src/main/java/com/clovi/app/timeShopItem/TimeShopItemService.java
+++ b/src/main/java/com/clovi/app/timeShopItem/TimeShopItemService.java
@@ -17,23 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TimeShopItemService {
-
     private final TimeShopItemRepository timeShopItemRepository;
 
-    private final TimeframeRepository timeFrameRepository;
+    private final TimeframeRepository timeframeRepository;
     private final ItemRepository itemRepository;
     private final ShopItemRepository shopItemRepository;
 
     @Transactional
-    public Long create(Member member, Long timeFrameId, Long itemId, Long shopItemId) {
-        if(timeShopItemRepository.existsByTimeIdAndItemIdAndShopItemIdAndDeletedIsFalse(timeFrameId,itemId,shopItemId)){
+    public Long createTimeShopItem(Long timeframeId, Long itemId, Long shopItemId, Member member) {
+        if(timeShopItemRepository.existsByTimeIdAndItemIdAndShopItemIdAndDeletedIsFalse(timeframeId, itemId, shopItemId)) {
             throw new DuplicateResourceException("timeShopItem");
         }
-        Timeframe timeFrame = timeFrameRepository.findByIdAndDeletedIsFalse(timeFrameId).orElseThrow(()-> new ResourceNotFoundException("timeframe",timeFrameId));
-        Item item = itemRepository.findByIdAndDeletedIsFalse(itemId).orElseThrow(()-> new ResourceNotFoundException("item",itemId));
-        ShopItem shopItem = shopItemRepository.findByIdAndDeletedIsFalse(shopItemId).orElseThrow(()-> new ResourceNotFoundException("shopItem",shopItemId));
-        TimeShopItem timeShopItem = new TimeShopItem(timeFrame,item,shopItem,member.getId());
-        TimeShopItem saved = timeShopItemRepository.save(timeShopItem);
+
+        Timeframe timeframe = timeframeRepository.findByIdAndDeletedIsFalse(timeframeId)
+                .orElseThrow(() -> new ResourceNotFoundException("timeframe", timeframeId));
+        Item item = itemRepository.findByIdAndDeletedIsFalse(itemId)
+                .orElseThrow(() -> new ResourceNotFoundException("item", itemId));
+        ShopItem shopItem = shopItemRepository.findByIdAndDeletedIsFalse(shopItemId)
+                .orElseThrow(() -> new ResourceNotFoundException("shopItem", shopItemId));
+
+        TimeShopItem saved = timeShopItemRepository.save(
+                new TimeShopItem(timeframe, item, shopItem, member.getId())
+        );
         return saved.getId();
     }
 }

--- a/src/main/java/com/clovi/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/clovi/exception/ResourceNotFoundException.java
@@ -6,10 +6,14 @@ public class ResourceNotFoundException extends BadRequestException {
   private static final String SERVER_MESSAGE = "존재하지 않는 객체 조회";
 
   public ResourceNotFoundException(String domain, final Long id) {
-    super(String.format("%s %s id: %d", domain, SERVER_MESSAGE, id), String.format("%s %s id: %d", domain, SERVER_MESSAGE, id), ERROR_CODE);
+    super(String.format("%s %s id : %d", domain, SERVER_MESSAGE, id), String.format("%s %s id : %d", domain, SERVER_MESSAGE, id), ERROR_CODE);
   }
 
-  public ResourceNotFoundException(String domain,final String code) {
+  public ResourceNotFoundException(String domain, final Long id1, final Long id2, final Long id3) {
+    super(String.format("%s %s id : %d, %d, %d", domain, SERVER_MESSAGE, id1, id2, id3), String.format("%s %s id : %d %d %d", domain, SERVER_MESSAGE, id1, id2, id3), ERROR_CODE);
+  }
+
+  public ResourceNotFoundException(String domain, final String code) {
     super(String.format("%s %s code : %s", domain, SERVER_MESSAGE, code), String.format("%s %s url : %s", domain, SERVER_MESSAGE, code), ERROR_CODE);
   }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/clovi?serverTimezone=Asia/Seoul
-    username: root
-    password:
+    url: ${MYSQL_URL} # jdbc:mysql://localhost:3306/clovi?serverTimezone=Asia/Seoul
+    username: ${MYSQL_USERNAME} # root
+    password: ${MYSQL_PASSWORD} #
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
### [[TimeShopItem] 시간에 대한 아이템 및 쇼핑몰 링크 관리 API](http://52.78.79.216:8080/swagger-ui/index.html)

- POST (연관관계 생성)
기존 : /api/v1/videos/{video_id}/timeframes/{time_frame_id}/items/{item_id}/shopitems/{shop_item_id}
변경 : /api/v1/timeframes/{timeframe_id}

- DELETE (연관관계 삭제)
추가 : **/api/v1/timeframes/{timeframe_id}**

---

### 수정사항 요약

- 시간에 대한 item 및 shopItem의 연관관계를 생성하는 POST API 변경
  - `video_id` 변수 삭제
  - `item_id`와 `shop_item_id`가 path variable이 아닌 query parameter로 주어지도록 변경
- 시간에 대한 item 및 shopItem의 연관관계를 삭제하는 DELETE API 추가
  - endpoint 구조는 위 POST와 동일