### PR TITLE
아이템 전체 정보 저장 API 기능 개발 및 삭제한 데이터 조회되는 오류 수정

### DIFF
--- a/src/main/java/com/clovi/app/base/domain/BaseEntity.java
+++ b/src/main/java/com/clovi/app/base/domain/BaseEntity.java
@@ -20,7 +20,10 @@ public class BaseEntity extends BaseTimeEntity{
   @LastModifiedBy
   protected Long lastModifiedBy;
 
-    public boolean isNotCreatedBy(Long userId) {
+  public boolean isNotCreatedBy(Long userId) {
       return userId.equals(createBy) == false;
     }
+  public boolean isNotDeleted(){
+    return this.getDeleted().equals(false);
+  }
 }

--- a/src/main/java/com/clovi/app/color/domain/Color.java
+++ b/src/main/java/com/clovi/app/color/domain/Color.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.checkerframework.common.aliasing.qual.Unique;
 
 @Entity
 @Getter
@@ -18,6 +19,7 @@ public class Color extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", nullable = false)
   private Long id;
+  @Unique
   private String name;
 
   public Color(String name) {

--- a/src/main/java/com/clovi/app/color/domain/ItemColor.java
+++ b/src/main/java/com/clovi/app/color/domain/ItemColor.java
@@ -29,13 +29,13 @@ public class ItemColor extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   private Color color;
-  @ManyToOne(fetch = FetchType.LAZY)
-  private ItemInfo itemInfo;
 
-  public ItemColor(ItemInfo itemInfo, Color color, String imgUrl, Long memberId) {
+  private Long itemInfoId;
+
+  public ItemColor(Long itemInfoId, Color color, String imgUrl, Long memberId) {
     this.imgUrl = imgUrl;
     this.color = color;
-    this.itemInfo = itemInfo;
+    this.itemInfoId = itemInfoId;
     this.createBy = memberId;
     this.lastModifiedBy = memberId;
   }

--- a/src/main/java/com/clovi/app/color/repository/ColorRepository.java
+++ b/src/main/java/com/clovi/app/color/repository/ColorRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ColorRepository extends JpaRepository<Color,Long> {
-    Optional<Color> findByName(String name);
+    Optional<Color> findByNameAndDeletedIsFalse(String name);
+
+    boolean existsByNameAndDeletedIsFalse(String name);
 }

--- a/src/main/java/com/clovi/app/color/repository/ItemColorRepository.java
+++ b/src/main/java/com/clovi/app/color/repository/ItemColorRepository.java
@@ -1,9 +1,17 @@
 package com.clovi.app.color.repository;
 
+import com.clovi.app.color.domain.Color;
 import com.clovi.app.color.domain.ItemColor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
+
 public interface ItemColorRepository extends JpaRepository<ItemColor, Long> {
     List<ItemColor> findAllByItemInfoId(Long itemInfoId);
+
+    Optional<ItemColor> findByItemInfoIdAndColorIdAndImgUrlAndDeletedIsFalse(Long itemInfoId, Long colorId, String imgUrl);
+
+    boolean existsByItemInfoIdAndColorIdAndImgUrlAndDeletedIsFalse(Long itemInfoId, Long colorId, String imgUrl);
+
 }

--- a/src/main/java/com/clovi/app/item/Item.java
+++ b/src/main/java/com/clovi/app/item/Item.java
@@ -8,6 +8,7 @@ import com.clovi.app.videoItem.VideoItem;
 import com.clovi.app.itemInfo.ItemInfo;
 import com.querydsl.core.annotations.QueryInit;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -49,6 +50,19 @@ public class Item extends BaseEntity {
     this.color = itemCreateRequest.getColor();
     this.imgUrl = itemCreateRequest.getImgUrl();
     this.itemInfo = itemInfo;
+  }
+
+  @Builder
+  public Item(Long id, String size, String color, String imgUrl, ItemInfo itemInfo, List<TimeShopItem> times, List<VideoItem> videoItems, Long userId) {
+    this.id = id;
+    this.size = size;
+    this.color = color;
+    this.imgUrl = imgUrl;
+    this.itemInfo = itemInfo;
+    this.times = times;
+    this.videoItems = videoItems;
+    this.createBy = userId;
+    this.lastModifiedBy = userId;
   }
 
   public void update(ItemUpdateRequest itemUpdateRequest, Long userId) {

--- a/src/main/java/com/clovi/app/item/ItemController.java
+++ b/src/main/java/com/clovi/app/item/ItemController.java
@@ -1,5 +1,6 @@
 package com.clovi.app.item;
 
+import com.clovi.app.color.ColorService;
 import com.clovi.app.item.dto.request.ItemCreateRequest;
 import com.clovi.app.item.dto.request.ItemUpdateRequest;
 import com.clovi.app.item.dto.response.ItemResponse;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class ItemController {
 
   private final ItemService itemService;
+  private final ColorService colorService;
 
   // 상품 조회 API
   @GetMapping("/items/{item_id}")
@@ -46,6 +48,8 @@ public class ItemController {
   })
   public ResponseEntity createItem(@Validated @RequestBody ItemCreateRequest itemCreateRequest, @AuthMember Member member){
     SavedId savedId = new SavedId(itemService.create(itemCreateRequest,member));
+    Long itemInfoId = itemCreateRequest.getItemInfoId();
+    colorService.save(itemCreateRequest.getColor(), itemCreateRequest.getImgUrl(), itemInfoId, member.getId()); // 컬러 엔티티 생성
     return ResponseEntity.created(
         URI.create("/api/v1/items" + savedId.getId())).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),
         ProcessStatus.SUCCESS,

--- a/src/main/java/com/clovi/app/item/ItemController.java
+++ b/src/main/java/com/clovi/app/item/ItemController.java
@@ -10,6 +10,7 @@ import com.clovi.app.base.dto.response.ProcessStatus;
 import com.clovi.app.member.Member;
 import com.clovi.app.base.dto.response.SavedId;
 import com.clovi.app.auth.helper.AuthMember;
+import com.clovi.app.size.SizeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 public class ItemController {
 
   private final ItemService itemService;
+  private final SizeService sizeService;
   private final ColorService colorService;
 
   // 상품 조회 API
@@ -49,6 +51,7 @@ public class ItemController {
   public ResponseEntity createItem(@Validated @RequestBody ItemCreateRequest itemCreateRequest, @AuthMember Member member){
     SavedId savedId = new SavedId(itemService.create(itemCreateRequest,member));
     Long itemInfoId = itemCreateRequest.getItemInfoId();
+    sizeService.save(itemCreateRequest.getSize(),itemInfoId, member.getId()); // 사이즈 엔티티 생성
     colorService.save(itemCreateRequest.getColor(), itemCreateRequest.getImgUrl(), itemInfoId, member.getId()); // 컬러 엔티티 생성
     return ResponseEntity.created(
         URI.create("/api/v1/items" + savedId.getId())).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),

--- a/src/main/java/com/clovi/app/item/ItemService.java
+++ b/src/main/java/com/clovi/app/item/ItemService.java
@@ -30,10 +30,10 @@ public class ItemService {
   }
   @Transactional
   public Long create(ItemCreateRequest itemCreateRequest, Member member) {
-    Long itemId = itemCreateRequest.getItemInfoId();
+    Long itemInfoId = itemCreateRequest.getItemInfoId();
     Long userId = member.getId();
-    ItemInfo findItemInfo = itemInfoRepository.findByIdAndDeletedIsFalse(itemId).orElseThrow(() -> new ResourceNotFoundException("Item", itemId));
-    Item newItem = new Item(itemCreateRequest, findItemInfo,userId);
+    ItemInfo findItemInfo = itemInfoRepository.findByIdAndDeletedIsFalse(itemInfoId).orElseThrow(() -> new ResourceNotFoundException("ItemInfo", itemInfoId));
+    Item newItem = itemCreateRequest.toEntity(findItemInfo,userId);
     Item saved = itemRepository.save(newItem);
     return saved.getId();
   }

--- a/src/main/java/com/clovi/app/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/com/clovi/app/item/dto/request/ItemCreateRequest.java
@@ -1,7 +1,8 @@
 package com.clovi.app.item.dto.request;
 
+import com.clovi.app.item.Item;
+import com.clovi.app.itemInfo.ItemInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,11 +26,20 @@ public class ItemCreateRequest {
   @Schema(description = "상품 이미지 링크", example = "https://image.msscdn.net/images/goods_img/20221204/2970721/2970721_1_500.jpg")
   private String imgUrl;
 
-  @Builder
   public ItemCreateRequest(Long itemInfoId, String size, String color, String imgUrl) {
     this.itemInfoId = itemInfoId;
     this.size = size;
     this.color = color;
     this.imgUrl = imgUrl;
+  }
+
+  public Item toEntity(ItemInfo itemInfo, Long userId){
+    return Item.builder()
+            .color(color)
+            .imgUrl(imgUrl)
+            .size(size)
+            .itemInfo(itemInfo)
+            .userId(userId)
+            .build();
   }
 }

--- a/src/main/java/com/clovi/app/itemInfo/ItemInfo.java
+++ b/src/main/java/com/clovi/app/itemInfo/ItemInfo.java
@@ -27,17 +27,8 @@ public class ItemInfo extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-
   private String name;
-
   private String brand;
-  @Lob
-  private String imgUrl;
-
-  private String color;
-
-  private Integer countOfColors;
-
   //=연관관계 매핑=//
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -49,29 +40,31 @@ public class ItemInfo extends BaseEntity {
   @OneToMany(mappedBy = "itemInfo", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   private List<ShopItem> shopItems = new ArrayList<>();
 
-  @Builder
-  public ItemInfo(String name, String color, String imgUrl) {
-    this.color = color;
-    this.name = name;
-    this.imgUrl = imgUrl;
-  }
   public ItemInfo(ItemInfoCreateRequest itemInfoCreateRequest, Category category, Long userId) {
     this.createBy = userId;
     this.lastModifiedBy = userId;
     this.name = itemInfoCreateRequest.getItemName();
     this.brand = itemInfoCreateRequest.getBrand();
     this.category = category;
-    this.color = itemInfoCreateRequest.getColor();
   }
+
+  @Builder
+  public ItemInfo(Long id, String name, String brand, ItemInfo parent, Category category, List<ShopItem> shopItems, Long userId) {
+    this.id = id;
+    this.name = name;
+    this.brand = brand;
+    this.parent = parent;
+    this.category = category;
+    this.shopItems = shopItems;
+    this.createBy = userId;
+    this.lastModifiedBy = userId;
+  }
+
   public void update(ItemInfoUpdateRequest itemInfoUpdateRequest, Category category, Long userId) {
     this.lastModifiedBy = userId;
     this.name = itemInfoUpdateRequest.getItemName();
     this.brand = itemInfoUpdateRequest.getBrand();
     this.category = category;
-    this.color = itemInfoUpdateRequest.getColor();
   }
 
-    public void addShopItem(ShopItem shopItem) {
-      this.shopItems.add(shopItem);
-    }
 }

--- a/src/main/java/com/clovi/app/itemInfo/ItemInfoRepository.java
+++ b/src/main/java/com/clovi/app/itemInfo/ItemInfoRepository.java
@@ -5,9 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ItemInfoRepository extends JpaRepository<ItemInfo,Long> {
-   // Optional<ItemInfo> findById(String itemId);
-   // Optional<ItemInfo> findByName(String name);
-   Optional<ItemInfo> findByNameAndBrandAndColor(String name, String brand, String color);
 
    Optional<ItemInfo> findByIdAndDeletedIsFalse(Long itemId);
 }

--- a/src/main/java/com/clovi/app/itemInfo/ItemInfoService.java
+++ b/src/main/java/com/clovi/app/itemInfo/ItemInfoService.java
@@ -2,9 +2,7 @@ package com.clovi.app.itemInfo;
 
 import com.clovi.app.category.Category;
 import com.clovi.app.category.repository.CategoryRepository;
-import com.clovi.app.color.repository.ItemColorRepository;
 import com.clovi.app.itemInfo.dto.response.ItemInfoResponse;
-import com.clovi.app.size.repository.ItemSizeRepository;
 import com.clovi.exception.ResourceNotFoundException;
 import com.clovi.exception.auth.NoPermissionDeleteException;
 import com.clovi.exception.auth.NoPermissionUpdateException;
@@ -21,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ItemInfoService {
   private final ItemInfoRepository itemInfoRepository;
-
   private final CategoryRepository categoryRepository;
 
 
@@ -38,7 +35,7 @@ public class ItemInfoService {
 
     Category category = categoryRepository.findByIdAndDeletedIsFalse(categoryId).orElseThrow(() -> new ResourceNotFoundException("category",categoryId));
 
-    ItemInfo newItemInfo = new ItemInfo(itemInfoCreateRequest,category,userId);
+    ItemInfo newItemInfo = itemInfoCreateRequest.toEntity(category,userId);
 
     ItemInfo saved = itemInfoRepository.save(newItemInfo);
 

--- a/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoCreateRequest.java
+++ b/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoCreateRequest.java
@@ -1,5 +1,7 @@
 package com.clovi.app.itemInfo.dto.request;
 
+import com.clovi.app.category.Category;
+import com.clovi.app.itemInfo.ItemInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -18,13 +20,15 @@ public class ItemInfoCreateRequest {
   @Schema(description = "상품명", example = "엠보 브이넥 니트")
   private String itemName;
 
-  @NotBlank(message = "상품 이미지 링크는 필수 항목입니다!")
-  @Schema(description = "상품 이미지 링크", example = "https://image.msscdn.net/images/goods_img/20221204/2970721/2970721_1_500.jpg")
-  private String itemImgUrl;
-
-  @Schema(description = "상품 색", example = "black")
-  private String color;
-
   @Schema(description = "카테고리", example = "203")
   private Long categoryId;
+
+  public ItemInfo toEntity(Category category,Long userId){
+    return ItemInfo.builder()
+            .brand(brand)
+            .name(itemName)
+            .category(category)
+            .userId(userId)
+            .build();
+  }
 }

--- a/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoUpdateRequest.java
+++ b/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoUpdateRequest.java
@@ -19,13 +19,6 @@ public class ItemInfoUpdateRequest {
   @Schema(description = "상품명", example = "엠보 브이넥 니트")
   private String itemName;
 
-  @NotBlank(message = "상품 이미지 링크는 필수 항목입니다!")
-  @Schema(description = "상품 이미지 링크", example = "https://image.msscdn.net/images/goods_img/20221204/2970721/2970721_1_500.jpg")
-  private String itemImgUrl;
-
-  @Schema(description = "상품 색", example = "black")
-  private String color;
-
   @Schema(description = "카테고리", example = "203")
   private Long categoryId;
 }

--- a/src/main/java/com/clovi/app/itemInfo/dto/response/ItemInfoResponse.java
+++ b/src/main/java/com/clovi/app/itemInfo/dto/response/ItemInfoResponse.java
@@ -43,7 +43,9 @@ public class ItemInfoResponse {
                 .name(itemInfo.getName())
                 .brand(itemInfo.getBrand())
                 .categoryId(itemInfo.getCategory().getId())
-                .shopItems(itemInfo.getShopItems().stream().map(shopItem -> ShopItemResponse.from(shopItem)).collect(Collectors.toList()))
+                .shopItems(itemInfo.getShopItems().stream()
+                        .filter(shopItem -> shopItem.isNotDeleted()) // 삭제되지 않은 것들만
+                        .map(shopItem -> ShopItemResponse.from(shopItem)).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/clovi/app/size/SizeController.java
+++ b/src/main/java/com/clovi/app/size/SizeController.java
@@ -45,7 +45,7 @@ public class SizeController {
             @ApiResponse(responseCode = "200", description = "Success Find all size of items ", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
     })
     public ResponseEntity getAllSizeByItemInfo(@Validated @PathVariable(name = "item_info_id") Long itemInfoId) {
-        List<String> response = sizeService.findAllColors(itemInfoId);
+        List<String> response = sizeService.findAllSize(itemInfoId);
         return ResponseEntity.ok(
                 new BaseResponse(response, HttpStatus.OK.value(), ProcessStatus.SUCCESS, MessageCode.SUCCESS_GET_LIST)
         );

--- a/src/main/java/com/clovi/app/size/SizeService.java
+++ b/src/main/java/com/clovi/app/size/SizeService.java
@@ -26,16 +26,22 @@ public class SizeService {
 
     public Long create(ItemSizeCreateRequest itemSizeCreateRequest, Member member, Long itemInfoId) {
         ItemInfo itemInfo = itemInfoRepository.findByIdAndDeletedIsFalse(itemInfoId).orElseThrow(() -> new ResourceNotFoundException("ItemInfo",itemInfoId));
-        String sizeName = itemSizeCreateRequest.getSize().trim();
-        Size size = sizeRepository.findByName(sizeName).orElse(
-                sizeRepository.save(new Size(sizeName))
-        );
-        ItemSize itemSize = new ItemSize(size,itemInfo,member.getId());
-        ItemSize saved = itemSizeRepository.save(itemSize);
+        String sizeName = itemSizeCreateRequest.getSize();
+        return save(sizeName,itemInfo.getId(),member.getId());
+    }
+
+    public List<String> findAllSize(Long itemInfoId) {
+        return itemSizeRepository.findAllByItemInfoId(itemInfoId).stream().map(ItemSize::getSizeName).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Long save(String sizeName,Long itemInfoId,Long userId){
+        sizeName = sizeName.trim();
+        Size size = sizeRepository.existsByNameAndDeletedIsFalse(sizeName) ?
+                sizeRepository.findByNameAndDeletedIsFalse(sizeName).get():sizeRepository.save(new Size(sizeName));
+        ItemSize saved = itemSizeRepository.existsByItemInfoIdAndSizeIdAndDeletedIsFalse(itemInfoId,size.getId()) ?
+                itemSizeRepository.findByItemInfoIdAndSizeIdAndDeletedIsFalse(itemInfoId, size.getId()).get() : itemSizeRepository.save(new ItemSize(size,itemInfoId,userId));
         return saved.getId();
     }
 
-    public List<String> findAllColors(Long itemInfoId) {
-        return itemSizeRepository.findAllByItemInfoId(itemInfoId).stream().map(ItemSize::getSizeName).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/clovi/app/size/domain/ItemSize.java
+++ b/src/main/java/com/clovi/app/size/domain/ItemSize.java
@@ -12,6 +12,7 @@ import javax.persistence.ManyToOne;
 
 import com.clovi.app.itemInfo.ItemInfo;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,12 +28,13 @@ public class ItemSize extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   private Size size;
-  @ManyToOne(fetch = FetchType.LAZY)
-  private ItemInfo itemInfo;
 
-  public ItemSize(Size size, ItemInfo itemInfo, Long memberId) {
+  private Long itemInfoId;
+
+  @Builder
+  public ItemSize(Size size, Long itemInfoId, Long memberId) {
     this.size = size;
-    this.itemInfo = itemInfo;
+    this.itemInfoId = itemInfoId;
     this.createBy = memberId;
     this.lastModifiedBy = memberId;
   }

--- a/src/main/java/com/clovi/app/size/domain/Size.java
+++ b/src/main/java/com/clovi/app/size/domain/Size.java
@@ -10,6 +10,7 @@ import com.clovi.app.base.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.checkerframework.common.aliasing.qual.Unique;
 
 @Entity
 @Getter
@@ -20,6 +21,7 @@ public class Size extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", nullable = false)
   private Long id;
+  @Unique
   private String name;
 
   public Size(String name) {

--- a/src/main/java/com/clovi/app/size/repository/ItemSizeRepository.java
+++ b/src/main/java/com/clovi/app/size/repository/ItemSizeRepository.java
@@ -4,7 +4,11 @@ import com.clovi.app.size.domain.ItemSize;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ItemSizeRepository extends JpaRepository<ItemSize,Long> {
     List<ItemSize> findAllByItemInfoId(Long itemInfoId);
+    Optional<ItemSize> findByItemInfoIdAndSizeIdAndDeletedIsFalse(Long itemInfoId, Long sizeId);
+
+    boolean existsByItemInfoIdAndSizeIdAndDeletedIsFalse(Long itemInfoId, Long sizeId);
 }

--- a/src/main/java/com/clovi/app/size/repository/SizeRepository.java
+++ b/src/main/java/com/clovi/app/size/repository/SizeRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface SizeRepository extends JpaRepository<Size,Long> {
-    Optional<Size> findByName(String name);
+    Optional<Size> findByNameAndDeletedIsFalse(String name);
+
+    boolean existsByNameAndDeletedIsFalse(String name);
 }

--- a/src/main/java/com/clovi/app/timeShopItem/dto/response/TimeShopItemResponse.java
+++ b/src/main/java/com/clovi/app/timeShopItem/dto/response/TimeShopItemResponse.java
@@ -32,6 +32,7 @@ public class TimeShopItemResponse {
     if(timeframe.getItems() != null) {
       this.items = timeframe.getItems()
               .stream()
+              .filter((item)->item.isNotDeleted())
               .map((item) -> new ItemShopItemResponse(item.getShopItem(),item.getItem()))
               .sorted(new ItemOrderComparator())
               .collect(Collectors.toList());


### PR DESCRIPTION
## Item
- @builder 패턴 추가
- 생성시 Color와 Size 엔티티에 중복 검사 후 ItemColor , Color , ItemSize, Size에 대한 데이터 추가 로직 작성 

## ItemInfo
- @builder 패턴 추가
- ItemInfoCreateRequest에 필요없는 필드 삭제 및 ToEntity 함수 추가
- 삭제된 데이터가 같이 조회되는 오류가 있었음. -> 하위 엔티티 조회시 filter로 삭제 표시가 되지 않은 것들만 반환 객체에 넣도록 수정