### PR TITLE
Feat: 빈 아이템 정보 생성 가능하도록 기능 수정

### DIFF
--- a/src/main/java/com/clovi/app/itemInfo/ItemInfoController.java
+++ b/src/main/java/com/clovi/app/itemInfo/ItemInfoController.java
@@ -45,7 +45,7 @@ public class ItemInfoController {
   @Operation(summary = "Create itemInfo", description = "Create information of item and save", responses = {
           @ApiResponse(responseCode = "201", description = "Success create", content = @Content(schema = @Schema(implementation = SavedId.class)))
   })
-  public ResponseEntity createItemInfo(@Validated @RequestBody ItemInfoCreateRequest itemInfoCreateRequest, @AuthMember Member member){
+  public ResponseEntity createItemInfo( @RequestBody ItemInfoCreateRequest itemInfoCreateRequest, @AuthMember Member member){
     SavedId savedId = new SavedId(itemInfoService.create(itemInfoCreateRequest,member));
     return ResponseEntity.created(
         URI.create("/api/v1/info/items" + savedId.getId())).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),ProcessStatus.SUCCESS,

--- a/src/main/java/com/clovi/app/itemInfo/ItemInfoService.java
+++ b/src/main/java/com/clovi/app/itemInfo/ItemInfoService.java
@@ -26,14 +26,16 @@ public class ItemInfoService {
     ItemInfo itemInfo = itemInfoRepository.findByIdAndDeletedIsFalse(itemInfoId).orElseThrow(() -> new ResourceNotFoundException("아이템",itemInfoId));
     return ItemInfoResponse.from(itemInfo);
   }
-  // 아래의 세 메소드 모두 유저 찾아서 권한 확인하는 부분 추가해야함.
+
   @Transactional
   public Long create(ItemInfoCreateRequest itemInfoCreateRequest, Member member){
     Long categoryId = itemInfoCreateRequest.getCategoryId();
 
     Long userId = member.getId();
 
-    Category category = categoryRepository.findByIdAndDeletedIsFalse(categoryId).orElseThrow(() -> new ResourceNotFoundException("category",categoryId));
+    Category category = categoryRepository.findByIdAndDeletedIsFalse(categoryId).orElse(
+            categoryRepository.findByIdAndDeletedIsFalse(10000L).get() // 빈 객체 생성시 사용되는 의미 없는 카테고리
+    );
 
     ItemInfo newItemInfo = itemInfoCreateRequest.toEntity(category,userId);
 

--- a/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoCreateRequest.java
+++ b/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoCreateRequest.java
@@ -12,11 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ItemInfoCreateRequest {
 
-  @NotBlank(message = "브랜드는 필수 항목입니다!")
   @Schema(description = "브랜드", example = "어누즈")
   private String brand;
 
-  @NotBlank(message = "상품명은 필수 항목입니다!")
   @Schema(description = "상품명", example = "엠보 브이넥 니트")
   private String itemName;
 

--- a/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoUpdateRequest.java
+++ b/src/main/java/com/clovi/app/itemInfo/dto/request/ItemInfoUpdateRequest.java
@@ -2,6 +2,7 @@ package com.clovi.app.itemInfo.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,7 @@ public class ItemInfoUpdateRequest {
   @Schema(description = "상품명", example = "엠보 브이넥 니트")
   private String itemName;
 
+  @NotNull(message = "카테고리 id는 필수 항목입니다!")
   @Schema(description = "카테고리", example = "203")
   private Long categoryId;
 }


### PR DESCRIPTION
api/v1/info/items 기능 변경 
Post : 생성시 아무 내용이 없어도 row가 DB에 추가되어 id가 반환되도록 변경 (categoryId는 10000으로 고정)
Put : 요청시 아이템명, 브랜드, 카테고리 ID가 필수 항목이 되게 변경