### PR TITLE
Feat: item, item_info 반환 객체에 colorAndImgUrlList 와 sizeList 추가

### DIFF
--- a/src/main/java/com/clovi/app/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/clovi/app/item/dto/response/ItemResponse.java
@@ -1,5 +1,7 @@
 package com.clovi.app.item.dto.response;
 
+import com.clovi.app.color.domain.ItemColor;
+import com.clovi.app.color.dto.response.ColorAndImgResponse;
 import com.clovi.app.itemInfo.ItemInfo;
 import com.clovi.app.item.Item;
 import java.util.ArrayList;
@@ -33,10 +35,16 @@ public class ItemResponse {
   @Schema(description = "정렬순서", example = "1")
   private int order;
 
-  List<ShopItemResponse> shops = new ArrayList<>();
-  List<ItemResponse> childItems = new ArrayList<>();
+  @Schema(description = "색상, 이미지 주소 리스트 ")
+  private List<ColorAndImgResponse> colorAndImgUrlList = new ArrayList<>();
+
+  @Schema(description = "사이즈 리스트")
+  private List<String> sizeList = new ArrayList<>();
+
+  private List<ShopItemResponse> shops = new ArrayList<>();
+  private List<ItemResponse> childItems = new ArrayList<>();
   @Builder
-  public ItemResponse(Long id, Long itemInfoId, String name, int order, String imgUrl, String color, String size, String brand, List<ShopItemResponse> shops, List<ItemResponse> childItems) {
+  public ItemResponse(Long id, Long itemInfoId, String name, int order, String imgUrl, String color, String size, String brand, List<ColorAndImgResponse> colorAndImgUrlList, List<String> sizeList, List<ShopItemResponse> shops, List<ItemResponse> childItems) {
     this.id = id;
     this.itemInfoId = itemInfoId;
     this.name = name;
@@ -45,6 +53,8 @@ public class ItemResponse {
     this.color = color;
     this.size = size;
     this.brand = brand;
+    this.colorAndImgUrlList = colorAndImgUrlList;
+    this.sizeList = sizeList;
     this.shops = shops;
     this.childItems = childItems;
   }
@@ -60,6 +70,8 @@ public class ItemResponse {
             .color(item.getColor())
             .size(item.getSize())
             .order(itemInfo.getCategory().getOrders())
+            .colorAndImgUrlList(itemInfo.getItemColors().stream().map(itemColor -> ColorAndImgResponse.from(itemColor)).collect(Collectors.toList()))
+            .sizeList(itemInfo.getItemSizes().stream().map(itemSize -> itemSize.getSize().getName()).collect(Collectors.toList()))
             .shops(itemInfo.getShopItems().stream().filter(shopItem -> shopItem.getShop().getId() != 100)
                     .map(shopItem -> ShopItemResponse.from(shopItem)).collect(Collectors.toList()))
             .build();

--- a/src/main/java/com/clovi/app/itemInfo/ItemInfo.java
+++ b/src/main/java/com/clovi/app/itemInfo/ItemInfo.java
@@ -1,6 +1,7 @@
 package com.clovi.app.itemInfo;
 
 import com.clovi.app.category.Category;
+import com.clovi.app.color.domain.ItemColor;
 import com.clovi.app.itemInfo.dto.request.ItemInfoCreateRequest;
 import com.clovi.app.itemInfo.dto.request.ItemInfoUpdateRequest;
 import com.clovi.app.base.domain.BaseEntity;
@@ -8,6 +9,7 @@ import com.clovi.app.shopItem.ShopItem;
 
 import javax.persistence.*;
 
+import com.clovi.app.size.domain.ItemSize;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +42,15 @@ public class ItemInfo extends BaseEntity {
   @OneToMany(mappedBy = "itemInfo", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   private List<ShopItem> shopItems = new ArrayList<>();
 
+  @OneToMany
+  @JoinColumn(name = "itemInfoId")
+  private List<ItemColor> itemColors = new ArrayList<>();
+
+  @OneToMany
+  @JoinColumn(name = "itemInfoId")
+  private List<ItemSize> itemSizes = new ArrayList<>();
+
+
   public ItemInfo(ItemInfoCreateRequest itemInfoCreateRequest, Category category, Long userId) {
     this.createBy = userId;
     this.lastModifiedBy = userId;
@@ -49,13 +60,12 @@ public class ItemInfo extends BaseEntity {
   }
 
   @Builder
-  public ItemInfo(Long id, String name, String brand, ItemInfo parent, Category category, List<ShopItem> shopItems, Long userId) {
+  public ItemInfo(Long id, String name, String brand, ItemInfo parent, Category category, Long userId) {
     this.id = id;
     this.name = name;
     this.brand = brand;
     this.parent = parent;
     this.category = category;
-    this.shopItems = shopItems;
     this.createBy = userId;
     this.lastModifiedBy = userId;
   }

--- a/src/main/java/com/clovi/app/itemInfo/dto/response/ItemInfoResponse.java
+++ b/src/main/java/com/clovi/app/itemInfo/dto/response/ItemInfoResponse.java
@@ -1,5 +1,6 @@
 package com.clovi.app.itemInfo.dto.response;
 
+import com.clovi.app.color.dto.response.ColorAndImgResponse;
 import com.clovi.app.itemInfo.ItemInfo;
 import com.clovi.app.shopItem.dto.response.ShopItemResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -28,12 +29,20 @@ public class ItemInfoResponse {
     @Schema(description = "쇼핑몰 객체")
     private List<ShopItemResponse> shopItems = new ArrayList<>();
 
+    @Schema(description = "색상, 이미지 주소 리스트 ")
+    private List<ColorAndImgResponse> colorAndImgUrlList = new ArrayList<>();
+
+    @Schema(description = "사이즈 리스트")
+    private List<String> sizeList = new ArrayList<>();
+
     @Builder
-    public ItemInfoResponse(Long id, String brand, String name, Long categoryId, List<ShopItemResponse> shopItems) {
+    public ItemInfoResponse(Long id, String brand, String name, Long categoryId,List<ColorAndImgResponse> colorAndImgUrlList, List<String> sizeList, List<ShopItemResponse> shopItems) {
         this.id = id;
         this.brand = brand;
         this.name = name;
         this.categoryId = categoryId;
+        this.colorAndImgUrlList = colorAndImgUrlList;
+        this.sizeList = sizeList;
         this.shopItems = shopItems;
     }
 
@@ -43,6 +52,8 @@ public class ItemInfoResponse {
                 .name(itemInfo.getName())
                 .brand(itemInfo.getBrand())
                 .categoryId(itemInfo.getCategory().getId())
+                .colorAndImgUrlList(itemInfo.getItemColors().stream().map(itemColor -> ColorAndImgResponse.from(itemColor)).collect(Collectors.toList()))
+                .sizeList(itemInfo.getItemSizes().stream().map(itemSize -> itemSize.getSize().getName()).collect(Collectors.toList()))
                 .shopItems(itemInfo.getShopItems().stream()
                         .filter(shopItem -> shopItem.isNotDeleted()) // 삭제되지 않은 것들만
                         .map(shopItem -> ShopItemResponse.from(shopItem)).collect(Collectors.toList()))


### PR DESCRIPTION
- 이전에는 아이템 별로 다시 API요청을 해서 위 정보들을 받아와야 했었음. -> 간단하게 변경
- 프론트에서 아이템관련 API 사용시 컬러 및 이미지 주소 리스트와 사이즈 리스트는 모든 기능에서 쓰임